### PR TITLE
multi-author posts + dark mode fixes

### DIFF
--- a/glitch-dot-cool/gatsby-node.js
+++ b/glitch-dot-cool/gatsby-node.js
@@ -44,12 +44,14 @@ module.exports.createPages = async ({ graphql, actions }) => {
   `)
   // create new pages
   blogResponse.data.allContentfulBlogPost.edges.forEach(post => {
-    createPage({
-      component: blogTemplate,
-      path: `/${slugify(post.node.author)}/${post.node.slug}`,
-      context: {
-        slug: post.node.slug,
-      },
+    post.node.author.split(",").forEach(author => {
+      createPage({
+        component: blogTemplate,
+        path: `/${slugify(author)}/${post.node.slug}`,
+        context: {
+          slug: post.node.slug,
+        },
+      })
     })
   })
 
@@ -103,6 +105,7 @@ module.exports.createPages = async ({ graphql, actions }) => {
       path: `${slugify(author.fieldValue)}/posts`,
       context: {
         author: author.fieldValue,
+        regexTerm: `/${author.fieldValue}/`,
       },
     })
   })

--- a/glitch-dot-cool/src/components/Forms/Filter.js
+++ b/glitch-dot-cool/src/components/Forms/Filter.js
@@ -33,7 +33,7 @@ const Form = styled.form`
 `
 
 const Label = styled.label`
-  font-size: 1.2rem;
+  font-size: 1.5rem;
   color: ${props => props.theme.colors.scale_2};
 `
 

--- a/glitch-dot-cool/src/components/Layout/footer.js
+++ b/glitch-dot-cool/src/components/Layout/footer.js
@@ -2,33 +2,32 @@ import React from "react"
 import styled from "styled-components"
 
 import { FooterLinks } from "./LinkIcons"
-import { StyledList, GatsbyLink } from "../../utils/utilComponents"
+import { GatsbyLink } from "../../utils/utilComponents"
 import { activeNavStyles } from "../../utils/utils"
 
 import measurements from "../../styles/measurements"
-import { chromaticAbberation } from "../../styles/animations"
 
 const Footer = () => {
   return (
     <StyledFooter>
       <Nav>
-        <GatsbyLink to="/" activeStyle={activeNavStyles}>
+        <GatsbyLink dark="true" to="/" activeStyle={activeNavStyles}>
           home
         </GatsbyLink>
 
-        <GatsbyLink to="/about/" activeStyle={activeNavStyles}>
+        <GatsbyLink dark="true" to="/about/" activeStyle={activeNavStyles}>
           about
         </GatsbyLink>
 
-        <GatsbyLink to="/projects/" activeStyle={activeNavStyles}>
+        <GatsbyLink dark="true" to="/projects/" activeStyle={activeNavStyles}>
           projects
         </GatsbyLink>
 
-        <GatsbyLink to="/members/" activeStyle={activeNavStyles}>
+        <GatsbyLink dark="true" to="/members/" activeStyle={activeNavStyles}>
           members
         </GatsbyLink>
 
-        <GatsbyLink to="/contact/" activeStyle={activeNavStyles}>
+        <GatsbyLink dark="true" to="/contact/" activeStyle={activeNavStyles}>
           contact
         </GatsbyLink>
       </Nav>
@@ -76,7 +75,6 @@ const Nav = styled.nav`
   a,
   a:visited {
     transition: 0.2s ease all;
-    color: ${props => props.theme.colors.footer_text};
   }
 
   @media only screen and (max-width: 395px) {

--- a/glitch-dot-cool/src/components/Posts/Post.js
+++ b/glitch-dot-cool/src/components/Posts/Post.js
@@ -2,22 +2,41 @@ import React from "react"
 import styled from "styled-components"
 
 import { GatsbyLink, Card } from "../../utils/utilComponents"
-import { slugify } from "../../utils/utils"
+import { slugify, parseAuthorLinks } from "../../utils/utils"
 
 const Post = ({ post }) => {
   const { author, slug, title } = post.node
+  const authorLinks = parseAuthorLinks(author)
 
   return (
     <Card>
       <TextContainer>
-        <GatsbyLink to={`/${slugify(author)}/${slug}`}>
+        <GatsbyLink to={`${slugify(authorLinks[0].name)}/${slug}`}>
           <h1>{title}</h1>
         </GatsbyLink>
-        <GatsbyLink to={`/${slugify(author)}/posts`}>
-          <h3>
-            by <strong>{author}</strong>
-          </h3>
-        </GatsbyLink>
+
+        <Authors>
+          <p>{`by `}</p>
+          {authorLinks.map((author, idx) => {
+            if (idx < authorLinks.length - 1) {
+              return (
+                <GatsbyLink to={author.slug}>
+                  <h3>
+                    <strong>{author.name},</strong>
+                  </h3>
+                </GatsbyLink>
+              )
+            } else {
+              return (
+                <GatsbyLink to={author.slug}>
+                  <h3>
+                    <strong>{author.name}</strong>
+                  </h3>
+                </GatsbyLink>
+              )
+            }
+          })}
+        </Authors>
       </TextContainer>
     </Card>
   )
@@ -32,4 +51,11 @@ const TextContainer = styled.div`
   padding: 2rem;
   width: 100%;
   background-color: ${props => props.theme.colors.card_overlay};
+`
+
+const Authors = styled.div`
+  p,
+  h3 {
+    display: inline;
+  }
 `

--- a/glitch-dot-cool/src/components/Posts/PostCard.js
+++ b/glitch-dot-cool/src/components/Posts/PostCard.js
@@ -2,11 +2,13 @@ import React from "react"
 import styled from "styled-components"
 
 import { GatsbyLink } from "../../utils/utilComponents"
-import { slugify } from "../../utils/utils"
+import { slugify, parseAuthorLinks } from "../../utils/utils"
 
 const PostCard = ({ post }) => {
+  const authors = parseAuthorLinks(post.node.author)
+
   return (
-    <GatsbyLink to={`/${slugify(post.node.author)}/${post.node.slug}`}>
+    <GatsbyLink to={`/${slugify(authors[0].name)}/${post.node.slug}`}>
       <Post>
         <h3>{post.node.title}</h3>
 

--- a/glitch-dot-cool/src/pages/posts.js
+++ b/glitch-dot-cool/src/pages/posts.js
@@ -6,12 +6,9 @@ import Layout from "../components/Layout/layout"
 import Head from "../components/Layout/head"
 import { GatsbyLink, PageTitle } from "../utils/utilComponents"
 import { Filter } from "../components/Forms/Filter"
-import { slugify } from "../utils/utils"
+import { slugify, parseAuthorLinks } from "../utils/utils"
 
 const Posts = () => {
-  const [filterTerm, setFilterTerm] = useState("")
-  const [filterResult, setfilterResult] = useState([])
-
   const data = useStaticQuery(graphql`
     query {
       allContentfulBlogPost(sort: { fields: publishedDate, order: DESC }) {
@@ -27,6 +24,9 @@ const Posts = () => {
     }
   `)
 
+  const [filterTerm, setFilterTerm] = useState("")
+  const [filterResult, setfilterResult] = useState([])
+
   useEffect(() => {
     const result = data.allContentfulBlogPost.edges.filter(post =>
       post.node.title.toLowerCase().includes(filterTerm.toLowerCase())
@@ -40,15 +40,29 @@ const Posts = () => {
       <PageTitle>posts</PageTitle>
       <Filter setFilterTerm={setFilterTerm} path="/tags" />
       {filterResult.map(post => {
+        const authors = parseAuthorLinks(post.node.author)
         return (
           <Post key={post.node.title}>
-            <GatsbyLink to={`/${slugify(post.node.author)}/${post.node.slug}`}>
+            <GatsbyLink to={`/${slugify(authors[0].name)}/${post.node.slug}`}>
               <h2>{post.node.title}</h2>
-            </GatsbyLink>
-            <p>{post.node.publishedDate}</p>
-            {`by `}
-            <GatsbyLink to={`/${slugify(post.node.author)}/posts`}>
-              <strong>{post.node.author}</strong>
+              <p>{post.node.publishedDate}</p>
+              <p style={{ display: "inline" }}>{`by `}</p>
+
+              {authors.map((author, idx) => {
+                if (idx < authors.length - 1) {
+                  return (
+                    <GatsbyLink to={author.slug}>
+                      <strong>{author.name},</strong>
+                    </GatsbyLink>
+                  )
+                } else {
+                  return (
+                    <GatsbyLink to={author.slug}>
+                      <strong>{author.name}</strong>
+                    </GatsbyLink>
+                  )
+                }
+              })}
             </GatsbyLink>
           </Post>
         )
@@ -61,10 +75,14 @@ export default Posts
 
 const Post = styled.div`
   padding: 2rem;
-  background-color: #fff;
+  background-color: ${props => props.theme.colors.scale_6};
   margin-top: 2rem;
 
   :last-child {
     margin-bottom: 2rem;
+  }
+
+  :hover {
+    background-color: ${props => props.theme.colors.scale_3};
   }
 `

--- a/glitch-dot-cool/src/pages/posts.js
+++ b/glitch-dot-cool/src/pages/posts.js
@@ -39,44 +39,70 @@ const Posts = () => {
       <Head title="posts" />
       <PageTitle>posts</PageTitle>
       <Filter setFilterTerm={setFilterTerm} path="/tags" />
-      {filterResult.map(post => {
-        const authors = parseAuthorLinks(post.node.author)
-        return (
-          <Post key={post.node.title}>
-            <GatsbyLink to={`/${slugify(authors[0].name)}/${post.node.slug}`}>
-              <h2>{post.node.title}</h2>
-              <p>{post.node.publishedDate}</p>
-              <p style={{ display: "inline" }}>{`by `}</p>
+      <PostContainer>
+        {filterResult.map(post => {
+          const authors = parseAuthorLinks(post.node.author)
+          return (
+            <Post key={post.node.title}>
+              <GatsbyLink to={`/${slugify(authors[0].name)}/${post.node.slug}`}>
+                <h2>{post.node.title}</h2>
+                <p>{post.node.publishedDate}</p>
+                <p style={{ display: "inline" }}>{`by `}</p>
 
-              {authors.map((author, idx) => {
-                if (idx < authors.length - 1) {
-                  return (
-                    <GatsbyLink to={author.slug}>
-                      <strong>{author.name},</strong>
-                    </GatsbyLink>
-                  )
-                } else {
-                  return (
-                    <GatsbyLink to={author.slug}>
-                      <strong>{author.name}</strong>
-                    </GatsbyLink>
-                  )
-                }
-              })}
-            </GatsbyLink>
-          </Post>
-        )
-      })}
+                {authors.map((author, idx) => {
+                  if (idx < authors.length - 1) {
+                    return (
+                      <GatsbyLink to={author.slug}>
+                        <strong>{author.name},</strong>
+                      </GatsbyLink>
+                    )
+                  } else {
+                    return (
+                      <GatsbyLink to={author.slug}>
+                        <strong>{author.name}</strong>
+                      </GatsbyLink>
+                    )
+                  }
+                })}
+              </GatsbyLink>
+            </Post>
+          )
+        })}
+      </PostContainer>
     </Layout>
   )
 }
 
 export default Posts
 
+const PostContainer = styled.div`
+  display: grid;
+  grid-gap: 2rem;
+  margin: 2rem 0 2rem 0;
+  grid-template-columns: repeat(auto-fit, minmax(32%, 1fr));
+
+  @media (max-width: 700px) {
+    grid-template-columns: repeat(auto-fit, minmax(50%, 1fr));
+  }
+
+  @media (max-width: 600px) {
+    grid-template-columns: repeat(auto-fit, minmax(100%, 1fr));
+  }
+`
+
 const Post = styled.div`
   padding: 2rem;
+  height: 100%;
   background-color: ${props => props.theme.colors.scale_6};
-  margin-top: 2rem;
+
+  h2 {
+    font-size: 2rem;
+  }
+
+  p,
+  a {
+    font-size: 1.6rem;
+  }
 
   :last-child {
     margin-bottom: 2rem;

--- a/glitch-dot-cool/src/pages/tags.js
+++ b/glitch-dot-cool/src/pages/tags.js
@@ -50,25 +50,34 @@ const Tags = () => {
 export default Tags
 
 const TagContainer = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  margin-bottom: 2rem;
+  display: grid;
+  grid-gap: 2rem;
+  margin: 2rem 0 2rem 0;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+
+  @media (max-width: 700px) {
+    grid-template-columns: repeat(auto-fit, minmax(50%, 1fr));
+  }
+
+  @media (max-width: 450px) {
+    grid-template-columns: repeat(auto-fit, minmax(100%, 1fr));
+  }
 `
 
 const Tag = styled(GatsbyLink)`
   display: inline-block;
-  width: calc(50% - 1rem);
   padding: 1rem;
-  margin-top: 2rem;
-  background-color: #fff;
+  background-color: ${props => props.theme.colors.scale_6};
 
-  :hover {
-    background-color: ${props => props.theme.colors.scale_2};
-    color: ${props => props.theme.colors.scale_5};
+  h2 {
+    font-size: 1.6rem;
+    transition: 0s;
   }
 
-  @media only screen and (max-width: 550px) {
-    width: 100%;
+  :hover {
+    background-color: ${props => props.theme.colors.scale_4};
+    h2 {
+      color: ${props => props.theme.colors.scale_6};
+    }
   }
 `

--- a/glitch-dot-cool/src/styles/animations.js
+++ b/glitch-dot-cool/src/styles/animations.js
@@ -1,16 +1,13 @@
 import { keyframes, css } from "styled-components"
+import { lightTheme } from "../styles/theme"
 
 const chromaticAbberationAnimation = keyframes`
     0% {
-      text-shadow: 1px 0px 1px ${props =>
-        props.theme.colors.valid}, -1px 0px 1px ${props =>
-  props.theme.colors.invalid};
+      text-shadow: 1px 0px 1px ${lightTheme.colors.valid}, -1px 0px 1px ${lightTheme.colors.invalid};
     }
 
     100% {
-      text-shadow: -1px 0px 2px ${props =>
-        props.theme.colors.valid}, 1px 0px 2px ${props =>
-  props.theme.colors.invalid};
+      text-shadow: -1px 0px 2px ${lightTheme.colors.valid}, 1px 0px 2px ${lightTheme.colors.invalid};
     }
 `
 

--- a/glitch-dot-cool/src/templates/author.js
+++ b/glitch-dot-cool/src/templates/author.js
@@ -34,7 +34,7 @@ const Author = ({
 export default Author
 
 export const query = graphql`
-  query($author: String!) {
+  query($author: String!, $regexTerm: String!) {
     contentfulAuthor(authorName: { eq: $author }) {
       authorName
       contactEmail
@@ -58,7 +58,7 @@ export const query = graphql`
       }
     }
     allContentfulBlogPost(
-      filter: { author: { eq: $author } }
+      filter: { author: { regex: $regexTerm } }
       sort: { fields: publishedDate, order: DESC }
     ) {
       edges {

--- a/glitch-dot-cool/src/templates/blog.js
+++ b/glitch-dot-cool/src/templates/blog.js
@@ -9,11 +9,11 @@ import Layout from "../components/Layout/layout"
 import Head from "../components/Layout/head"
 import DistroLinks from "../components/Profile/distroLinks"
 import measurements from "../styles/measurements"
-import { slugify, renderOptions } from "../utils/utils"
+import { slugify, renderOptions, parseAuthorLinks } from "../utils/utils"
 import { GatsbyLink } from "../utils/utilComponents"
 
 const Blog = props => {
-  let authorSlug = `/${slugify(props.data.contentfulBlogPost.author)}/posts`
+  const authorLinks = parseAuthorLinks(props.data.contentfulBlogPost.author)
   let blogContent = props.data.contentfulBlogPost.body.json
   let parsedLinks
 
@@ -44,11 +44,21 @@ const Blog = props => {
           <h1>{props.data.contentfulBlogPost.title}</h1>
           <p>
             {`by `}
-            <strong>
-              <GatsbyLink to={authorSlug}>
-                {props.data.contentfulBlogPost.author}
-              </GatsbyLink>
-            </strong>
+            {authorLinks.map((author, idx) => {
+              if (idx < authorLinks.length - 1) {
+                return (
+                  <strong key={author.name}>
+                    <GatsbyLink to={author.slug}>{author.name},</GatsbyLink>
+                  </strong>
+                )
+              } else {
+                return (
+                  <strong key={author.name}>
+                    <GatsbyLink to={author.slug}>{author.name}</GatsbyLink>
+                  </strong>
+                )
+              }
+            })}
           </p>
           <p>{props.data.contentfulBlogPost.publishedDate}</p>
         </BlogHeader>

--- a/glitch-dot-cool/src/templates/tag.js
+++ b/glitch-dot-cool/src/templates/tag.js
@@ -10,33 +10,7 @@ import {
   StyledButton,
   PageTitle,
 } from "../utils/utilComponents"
-import { slugify } from "../utils/utils"
-
-const Post = styled.div`
-  padding: 2rem;
-  background-color: #fff;
-  margin-top: 2rem;
-
-  :last-child {
-    margin-bottom: 2rem;
-  }
-`
-
-export const query = graphql`
-  query($tag: String!) {
-    allContentfulBlogPost(filter: { tags: { eq: $tag } }) {
-      edges {
-        node {
-          tags
-          slug
-          title
-          author
-          publishedDate(formatString: "MMMM Do, YYYY")
-        }
-      }
-    }
-  }
-`
+import { slugify, parseAuthorLinks } from "../utils/utils"
 
 const Tag = props => {
   return (
@@ -55,24 +29,42 @@ const Tag = props => {
       </GatsbyLink>
       <ol>
         {props.data.allContentfulBlogPost.edges.map(post => {
+          const authors = parseAuthorLinks(post.node.author)
           return (
             <Post key={post.node.title}>
               <StyledList>
                 <GatsbyLink
-                  to={`/${slugify(post.node.author)}/${post.node.slug}`}
+                  to={`/${slugify(authors[0].name)}/${post.node.slug}`}
                 >
                   <h2>{post.node.title}</h2>
                 </GatsbyLink>
               </StyledList>
-              <p>
-                by{" "}
-                <StyledList>
-                  <GatsbyLink to={`/${slugify(post.node.author)}/posts`}>
-                    {post.node.author}
-                  </GatsbyLink>
-                </StyledList>
-                {` - ${post.node.publishedDate}`}
-              </p>
+
+              <Authors>
+                <p style={{ display: "inline" }}>{`by: `}</p>
+                {authors.map((author, idx) => {
+                  if (idx < authors.length - 1) {
+                    return (
+                      <GatsbyLink to={author.slug}>
+                        <h3>
+                          <strong>{author.name},</strong>
+                        </h3>
+                      </GatsbyLink>
+                    )
+                  } else {
+                    return (
+                      <GatsbyLink to={author.slug}>
+                        <h3>
+                          <strong>{author.name}</strong>
+                        </h3>
+                      </GatsbyLink>
+                    )
+                  }
+                })}
+                <p
+                  style={{ display: "inline" }}
+                >{` - ${post.node.publishedDate}`}</p>
+              </Authors>
             </Post>
           )
         })}
@@ -82,3 +74,43 @@ const Tag = props => {
 }
 
 export default Tag
+
+export const query = graphql`
+  query($tag: String!) {
+    allContentfulBlogPost(filter: { tags: { eq: $tag } }) {
+      edges {
+        node {
+          tags
+          slug
+          title
+          author
+          publishedDate(formatString: "MMMM Do, YYYY")
+        }
+      }
+    }
+  }
+`
+
+const Post = styled.div`
+  padding: 2rem;
+  background-color: ${props => props.theme.colors.scale_6};
+  margin-top: 2rem;
+
+  :last-child {
+    margin-bottom: 2rem;
+  }
+`
+
+const Authors = styled.div`
+  p,
+  h3 {
+    display: inline;
+    transition: 0s;
+  }
+
+  a:hover,
+  h2:hover,
+  h3:hover {
+    color: ${props => props.theme.colors.scale_4};
+  }
+`

--- a/glitch-dot-cool/src/utils/utilComponents.js
+++ b/glitch-dot-cool/src/utils/utilComponents.js
@@ -9,10 +9,11 @@ export const GatsbyLink = styled(props => <Link to={props.to} {...props} />)`
   text-decoration: none;
   transition: 0.2s ease all;
   color: ${props =>
-    props.dark ? props.theme.colors.scale_5 : props.theme.colors.scale_1};
+    props.dark ? props.theme.colors.footer_text : props.theme.colors.scale_1};
 
   :hover {
-    color: ${props => props.theme.colors.footer_text_hover};
+    // color: ${props => props.theme.colors.footer_text_hover};
+    color: ${props => props.theme.colors.scale_3};
     ${chromaticAbberation}
   }
 `

--- a/glitch-dot-cool/src/utils/utils.js
+++ b/glitch-dot-cool/src/utils/utils.js
@@ -141,4 +141,21 @@ const mergePostsAndSortByDate = (posts, projects) => {
   return allPosts
 }
 
-export { slugify, activeNavStyles, renderOptions, mergePostsAndSortByDate }
+const parseAuthorLinks = authors => {
+  const authorLinks = []
+  authors.split(",").forEach(author =>
+    authorLinks.push({
+      name: author,
+      slug: `/${slugify(author)}/posts`,
+    })
+  )
+  return authorLinks
+}
+
+export {
+  slugify,
+  activeNavStyles,
+  renderOptions,
+  mergePostsAndSortByDate,
+  parseAuthorLinks,
+}


### PR DESCRIPTION
it's now possible to have blog posts authored by multiple contributors. when entering a collaborative post in contentful, simply add a comma separated list of authors. 

on the site, the post will be rendered on each contributor's profile separately, but the post will appear as a single entity on the homepage or under /posts.

there are also some dark mode fixes:
- fixed a number of cards w/ improper background colors in dark mode
- fixed chromatic aberration hover effect, broken in initial dark mode update

and a couple layout improvements:
-improved density of items on `/tags` and `/posts` 
